### PR TITLE
Добавление тестов для компонентов прогнозирования

### DIFF
--- a/tests/test_prediction_generator.py
+++ b/tests/test_prediction_generator.py
@@ -1,0 +1,48 @@
+import unittest
+from unittest.mock import patch, mock_open
+import pandas as pd
+
+from generators import prediction_generator as pg
+
+class TestPredictionGenerator(unittest.TestCase):
+    def setUp(self):
+        self.df = pd.DataFrame({
+            'f1': [1, 2, 3, 4],
+            'f2': [2, 3, 4, 5],
+            'target': [3, 5, 7, 9]
+        })
+
+    def test_build_prediction_numbers_with_request(self):
+        with patch.object(pg, 'request') as mock_request:
+            mock_request.forms.get.side_effect = lambda k: {'target_col': '3', 'features': '5 6'}[k]
+            html = pg.build_prediction_numbers(self.df)
+            self.assertIn('Прогнозируемое значение', html)
+            self.assertIn('target', html)
+            self.assertIn('5.00', html)
+            self.assertIn('6.00', html)
+
+    def test_build_prediction_numbers_valid(self):
+        html = pg.build_prediction_numbers_(self.df, 2, [5.0, 6.0])
+        self.assertIn('Прогнозируемое значение', html)
+        self.assertIn('target', html)
+
+    def test_build_prediction_numbers_invalid_target(self):
+        html = pg.build_prediction_numbers_(self.df, 5, [1, 2])
+        self.assertIn('Ошибка', html)
+
+    def test_build_prediction_numbers_feature_mismatch(self):
+        html = pg.build_prediction_numbers_(self.df, 2, [1])
+        self.assertIn('Ошибка', html)
+
+    @patch('generators.prediction_generator.os.makedirs')
+    @patch('generators.prediction_generator.open', new_callable=mock_open)
+    def test_save_data_with_prediction(self, mock_file, mock_makedirs):
+        with patch.object(self.df, 'to_csv') as mock_to_csv:
+            pg.save_data_with_prediction(self.df, 'result')
+            mock_makedirs.assert_called_once_with('data/variant4', exist_ok=True)
+            mock_to_csv.assert_called_once()
+            mock_file.assert_called_once()
+            mock_file().write.assert_called_once_with('result')
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_prediction_service.py
+++ b/tests/test_prediction_service.py
@@ -1,0 +1,40 @@
+import unittest
+from unittest.mock import patch
+import pandas as pd
+
+import services.prediction_service as ps
+
+class TestPredictionService(unittest.TestCase):
+    def setUp(self):
+        self.df = pd.DataFrame({
+            'f1': [1, 2],
+            'f2': [2, 3],
+            'target': [3, 5]
+        })
+
+    @patch('services.prediction_service.build_prediction_numbers')
+    def test_build_prediction_success(self, mock_build):
+        mock_build.return_value = '<div>ok</div>'
+        html, err = ps.build_prediction(self.df)
+        self.assertEqual(html, '<div>ok</div>')
+        self.assertIsNone(err)
+        mock_build.assert_called_once_with(self.df)
+
+    @patch('services.prediction_service.build_prediction_numbers')
+    def test_build_prediction_error(self, mock_build):
+        mock_build.side_effect = Exception('fail')
+        html, err = ps.build_prediction(self.df)
+        self.assertEqual(html, '')
+        self.assertIn('alert-danger', err)
+
+    @patch('services.prediction_service.save_data_with_prediction')
+    @patch('services.prediction_service.build_prediction_numbers_')
+    def test_save_prediction(self, mock_build, mock_save):
+        mock_build.return_value = 'result'
+        msg = ps.save_prediction(self.df, 2, [1.0, 2.0])
+        mock_build.assert_called_once_with(self.df, 2, [1.0, 2.0])
+        mock_save.assert_called_once_with(self.df, 'result')
+        self.assertIn('успешно', msg)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Сводка
- добавить покрытие unittest для `prediction_generator`
- добавить тесты для `prediction_service`

## Тестирование
- `python -m unittest discover -v тесты`